### PR TITLE
Generate cobbled deepslate instead; also affect (smooth) stone generation

### DIFF
--- a/src/main/java/me/diced/deepslategenerator/DeepslateGenerator.java
+++ b/src/main/java/me/diced/deepslategenerator/DeepslateGenerator.java
@@ -5,12 +5,26 @@ import net.minecraft.block.Block;
 import net.minecraft.block.Blocks;
 import net.minecraft.util.ActionResult;
 
+import java.util.Random;
+
 public class DeepslateGenerator implements ModInitializer {
     @Override
     public void onInitialize() {
-        CobblestoneGeneratedCallback.EVENT.register((world, pos) -> {
-            Block block = world.getBlockState(pos).getBlock() == Blocks.OBSIDIAN ? Blocks.OBSIDIAN : (pos.getY() > 0 ? Blocks.COBBLESTONE : Blocks.DEEPSLATE);
-            world.setBlockState(pos, block.getDefaultState());
+        StoneGeneratedCallback.EVENT.register((world, pos) -> {
+            int y = pos.getY();
+            if (y > 7) {
+                return ActionResult.PASS;
+            }
+            if (y > 0 && (new Random()).nextInt(8) < y) {
+                return ActionResult.PASS;
+            }
+            Block replaceThis = world.getBlockState(pos).getBlock();
+
+            if (replaceThis == Blocks.STONE) {
+                world.setBlockState(pos, Blocks.DEEPSLATE.getDefaultState());
+            } else if (replaceThis == Blocks.COBBLESTONE) {
+                world.setBlockState(pos, Blocks.COBBLED_DEEPSLATE.getDefaultState());
+            }
             return ActionResult.PASS;
         });
     }

--- a/src/main/java/me/diced/deepslategenerator/StoneGeneratedCallback.java
+++ b/src/main/java/me/diced/deepslategenerator/StoneGeneratedCallback.java
@@ -7,10 +7,10 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 // https://fabricmc.net/wiki/tutorial:events
-public interface CobblestoneGeneratedCallback {
-    Event<CobblestoneGeneratedCallback> EVENT = EventFactory.createArrayBacked(CobblestoneGeneratedCallback.class,
+public interface StoneGeneratedCallback {
+    Event<StoneGeneratedCallback> EVENT = EventFactory.createArrayBacked(StoneGeneratedCallback.class,
             (listeners) -> (world, pos) -> {
-                for (CobblestoneGeneratedCallback listener : listeners) {
+                for (StoneGeneratedCallback listener : listeners) {
                     ActionResult result = listener.interact(world, pos);
 
                     if(result != ActionResult.PASS) {

--- a/src/main/java/me/diced/deepslategenerator/mixin/FluidBlockMixin.java
+++ b/src/main/java/me/diced/deepslategenerator/mixin/FluidBlockMixin.java
@@ -1,6 +1,6 @@
 package me.diced.deepslategenerator.mixin;
 
-import me.diced.deepslategenerator.CobblestoneGeneratedCallback;
+import me.diced.deepslategenerator.StoneGeneratedCallback;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.FluidBlock;
 import net.minecraft.util.ActionResult;
@@ -13,9 +13,16 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(FluidBlock.class)
 public abstract class FluidBlockMixin {
-    @Inject(at = @At(value = "INVOKE", target = "Lnet/minecraft/block/FluidBlock;playExtinguishSound(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;)V"), method = "receiveNeighborFluids", cancellable = true)
-    private void onGenerate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
-        ActionResult result = CobblestoneGeneratedCallback.EVENT.invoker().interact(world, pos);
+    @Inject(
+            method = "receiveNeighborFluids",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/block/FluidBlock;playExtinguishSound(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;)V"
+            ),
+            cancellable = true
+    )
+    private void deepslateGenerator$onGenerate(World world, BlockPos pos, BlockState state, CallbackInfoReturnable<Boolean> cir) {
+        ActionResult result = StoneGeneratedCallback.EVENT.invoker().interact(world, pos);
 
         if(result == ActionResult.FAIL) {
             cir.cancel();

--- a/src/main/java/me/diced/deepslategenerator/mixin/LavaFluidMixin.java
+++ b/src/main/java/me/diced/deepslategenerator/mixin/LavaFluidMixin.java
@@ -1,0 +1,34 @@
+package me.diced.deepslategenerator.mixin;
+
+import me.diced.deepslategenerator.StoneGeneratedCallback;
+import net.minecraft.block.BlockState;
+import net.minecraft.fluid.FluidState;
+import net.minecraft.fluid.LavaFluid;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+import net.minecraft.world.WorldAccess;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(LavaFluid.class)
+public abstract class LavaFluidMixin {
+    @Inject(
+            method = "flow",
+            at = @At(
+                    value = "INVOKE",
+                    target = "Lnet/minecraft/fluid/LavaFluid;playExtinguishEvent(Lnet/minecraft/world/WorldAccess;Lnet/minecraft/util/math/BlockPos;)V"
+            ),
+            cancellable = true
+    )
+    private void deepslateGenerator$onFlow(WorldAccess world, BlockPos pos, BlockState state, Direction direction, FluidState fluidState, CallbackInfo ci) {
+        ActionResult result = StoneGeneratedCallback.EVENT.invoker().interact((World) world, pos);
+
+        if(result == ActionResult.FAIL) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/deepslategenerator.mixins.json
+++ b/src/main/resources/deepslategenerator.mixins.json
@@ -2,9 +2,10 @@
   "required": true,
   "minVersion": "0.8",
   "package": "me.diced.deepslategenerator.mixin",
-  "compatibilityLevel": "JAVA_16",
+  "compatibilityLevel": "JAVA_17",
   "mixins": [
-    "FluidBlockMixin"
+    "FluidBlockMixin",
+    "LavaFluidMixin"
   ],
   "client": [
   ],


### PR DESCRIPTION
This PR modifies cobblestone-gen replacement to instead replace cobblestone with cobbled deepslate, which is more analogous to cobblestone than is regular deepslate. It also expands the replacement feature to (smooth) stone generated from lava flowing onto water blocks, replacing the stone with regular deepslate. Furthermore, this PR uses a Random to implement randomized replacement of stone/cobblestone between y=0 and y=8 (exclusive), such that (cobbled) deepslate has an 87.5% chance to replace (cobble)stone at y=1, a 75% chance at y=2, and so forth, mirroring the gradual transition from stone to deepslate found in vanilla terrain generation.